### PR TITLE
Update the API endpoint

### DIFF
--- a/src/ExchangeRatesAPI.php
+++ b/src/ExchangeRatesAPI.php
@@ -14,10 +14,10 @@ namespace BenMajor\ExchangeRatesAPI;
 class ExchangeRatesAPI
 {
     # Default API URL:
-    const API_URL_SSL = 'https://api.exchangeratesapi.io/';
+    const API_URL_SSL = 'https://api.exchangerate.host/';
     
     # Free plan API URL:
-    const API_URL_NON_SSL = 'http://api.exchangeratesapi.io/';
+    const API_URL_NON_SSL = 'http://api.exchangerate.host/';
     
     # Fetch date
     private $fetchDate;


### PR DESCRIPTION
The previous API provider introduced rate limiting, so switching to
a new provider